### PR TITLE
[SP-1007] Enhance Neo4j browser for our usecase

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "homepage": "https://neo4j.com/developer/guide-neo4j-browser/",
   "main": "dist/index.html",
   "scripts": {
-    "build": "NODE_ENV=\"production\" webpack --config ./build_scripts/webpack.config.js",
+    "build": "scripts/generate_credentials.sh > src/shared/credential/neo4jCredential.js && NODE_ENV=\"production\" webpack --config ./build_scripts/webpack.config.js",
     "dev": "jest --watch",
     "e2e": "cypress run",
     "e2e-aura": "CYPRESS_E2E_TEST_ENV=\"aura\" cypress run",

--- a/scripts/generate_credentials.sh
+++ b/scripts/generate_credentials.sh
@@ -1,0 +1,5 @@
+echo "export default {"
+echo "  userName: \"$NEO4J_USERNAME\","
+echo "  password: \"$NEO4J_PASSWORD\","
+echo "  host: \"$NEO4J_HOST\""
+echo "}"

--- a/src/browser/modules/Main/Main.jsx
+++ b/src/browser/modules/Main/Main.jsx
@@ -37,6 +37,7 @@ import SyncConsentBanner from './SyncConsentBanner'
 import ErrorBoundary from 'browser-components/ErrorBoundary'
 import { useSlowConnectionState } from './main.hooks'
 import AutoExecButton from '../Stream/auto-exec-button'
+import NoMutationBanner from './NoMutationBanner'
 
 const Main = React.memo(function Main(props) {
   const [past5Sec, past10Sec] = useSlowConnectionState(props)
@@ -87,12 +88,7 @@ const Main = React.memo(function Main(props) {
           Server is taking a long time to respond...
         </WarningBanner>
       </Render>
-      <Render if={props.useBrowserSync}>
-        <SyncReminderBanner />
-      </Render>
-      <Render if={props.useBrowserSync}>
-        <SyncConsentBanner />
-      </Render>
+      <NoMutationBanner />
       <ErrorBoundary>
         <Stream />
       </ErrorBoundary>

--- a/src/browser/modules/Main/NoMutationBanner.jsx
+++ b/src/browser/modules/Main/NoMutationBanner.jsx
@@ -1,0 +1,15 @@
+import React from 'react'
+import { StyledSyncReminderSpan, NoMutationBannerStyle } from './styled'
+import Render from 'browser-components/Render'
+const NoMutationBanner = React.memo(function NoMutationBanner() {
+  return (
+    <Render if={true}>
+      <NoMutationBannerStyle height="100px">
+        <StyledSyncReminderSpan>
+          Please don't make queries that mutate the state of this db!
+        </StyledSyncReminderSpan>
+      </NoMutationBannerStyle>
+    </Render>
+  )
+})
+export default NoMutationBanner

--- a/src/browser/modules/Main/styled.jsx
+++ b/src/browser/modules/Main/styled.jsx
@@ -80,8 +80,8 @@ export const StyledCodeBlockFrame = styled(StyledCodeBlock)`
   cursor: pointer;
 `
 
-export const SyncDisconnectedBanner = styled(Banner)`
-  background-color: ${props => props.theme.auth};
+export const NoMutationBannerStyle = styled(Banner)`
+  background-color: #a64452;
   display: flex;
   justify-content: space-between;
 `

--- a/src/shared/credential/.gitignore
+++ b/src/shared/credential/.gitignore
@@ -1,0 +1,1 @@
+neo4jCredential.js


### PR DESCRIPTION
Steps:
1.`docker run     --name testneo4j     -p7474:7474 -p7687:7687     -d     -v $HOME/neo4j/data:/data     -v $HOME/neo4j/logs:/logs     -v $HOME/neo4j/import:/var/lib/neo4j/import     -v $HOME/neo4j/plugins:/plugins     --env NEO4J_AUTH=neo4j/test     neo4j:latest`
2. download neo4j credentials from SSM and export them to environment variables
3. run `yarn run build`, and it basically generates a json file that contains those information and build the static website
4. this static site automatically uses the credential logs in to our Neo4jDb.
![image](https://user-images.githubusercontent.com/5493592/89599993-cb016300-d815-11ea-9c31-8694c733a6c6.png)
